### PR TITLE
Add machete and remove cargo-udeps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "tracel-xtask"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "tracel-xtask-macros"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/tracel-xtask-macros/src/lib.rs
+++ b/crates/tracel-xtask-macros/src/lib.rs
@@ -598,7 +598,7 @@ fn get_subcommand_variant_map() -> HashMap<&'static str, proc_macro2::TokenStrea
                 All,
                 #[doc = r"Run cargo-deny Lint dependency graph to ensure all dependencies meet requirements `<https://crates.io/crates/cargo-deny>`. [default]"]
                 Deny,
-                #[doc = r"Run cargo-udeps to find unused dependencies `<https://crates.io/crates/cargo-udeps>`"]
+                #[doc = r"Run cargo-machete to find unused dependencies `<https://crates.io/crates/cargo-machete>`"]
                 Unused,
             },
         ),

--- a/crates/tracel-xtask/src/commands/dependencies.rs
+++ b/crates/tracel-xtask/src/commands/dependencies.rs
@@ -2,11 +2,9 @@ use anyhow::Ok;
 use strum::IntoEnumIterator;
 
 use crate::{
-    commands::CARGO_NIGHTLY_MSG,
     endgroup, group,
     utils::{
         cargo::ensure_cargo_crate_is_installed, process::run_process,
-        rustup::is_current_toolchain_nightly,
     },
 };
 
@@ -16,7 +14,7 @@ pub struct DependenciesCmdArgs {}
 pub fn handle_command(args: DependenciesCmdArgs) -> anyhow::Result<()> {
     match args.get_command() {
         DependenciesSubCommand::Deny => run_cargo_deny(),
-        DependenciesSubCommand::Unused => run_cargo_udeps(),
+        DependenciesSubCommand::Unused => run_cargo_machete(),
         DependenciesSubCommand::All => DependenciesSubCommand::iter()
             .filter(|c| *c != DependenciesSubCommand::All)
             .try_for_each(|c| handle_command(DependenciesCmdArgs { command: Some(c) })),
@@ -39,22 +37,19 @@ fn run_cargo_deny() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Run cargo-udeps
-fn run_cargo_udeps() -> anyhow::Result<()> {
-    if is_current_toolchain_nightly() {
-        ensure_cargo_crate_is_installed("cargo-udeps", None, None, false)?;
-        // Run cargo udeps
-        group!("Cargo: run unused dependencies checks");
-        run_process(
-            "cargo",
-            &vec!["udeps"],
-            None,
-            None,
-            "Unused dependencies found!",
-        )?;
-        endgroup!();
-    } else {
-        error!("{}", CARGO_NIGHTLY_MSG);
-    }
+/// Run cargo-machete
+fn run_cargo_machete() -> anyhow::Result<()> {
+    ensure_cargo_crate_is_installed("cargo-machete", None, None, false)?;
+    // Run cargo machete
+    group!("Cargo: run unused dependencies checks");
+    run_process(
+        "cargo",
+        &vec!["machete"],
+        None,
+        None,
+        "Unused dependencies found!",
+    )?;
+    endgroup!();
+
     Ok(())
 }

--- a/crates/tracel-xtask/src/commands/dependencies.rs
+++ b/crates/tracel-xtask/src/commands/dependencies.rs
@@ -3,9 +3,7 @@ use strum::IntoEnumIterator;
 
 use crate::{
     endgroup, group,
-    utils::{
-        cargo::ensure_cargo_crate_is_installed, process::run_process,
-    },
+    utils::{cargo::ensure_cargo_crate_is_installed, process::run_process},
 };
 
 #[tracel_xtask_macros::declare_command_args(None, DependenciesSubCommand)]


### PR DESCRIPTION
# Related Issues

https://github.com/tracel-ai/xtask/issues/3

# Checks

Looks like test validation process is not established for this repo, I did following checks. If not enough, pleas let me know how to deal with additional checks and tests.

##  No Detection Case

After building, run the command with execution files in the target dir.
As expected no errors occurred.
```
% cargo build                                   
% ./target/xtask/debug/xtask dependencies unused
[2024-09-08T12:23:34Z INFO  tracel_xtask] Execution environment: std
[2024-09-08T12:23:34Z INFO  tracel_xtask::commands::dependencies] Cargo: run unused dependencies checks
[2024-09-08T12:23:34Z INFO  tracel_xtask::utils::process] Command line: cargo machete
Analyzing dependencies of crates in this directory...
cargo-machete didn't find any unused dependencies in .. Good job!
Done!
```


## Detection Case

To detect unused packages, I added `cfg-if` for instances and executed the command.

```
% cargo add cfg-if                    
error: `cargo add` could not determine which package to modify. Use the `--package` option to specify a package. 
available packages: tracel-xtask, tracel-xtask-macros, xtask
toru@toru-mac xtask % cargo add cfg-if --package tracel-xtask
    Updating crates.io index
      Adding cfg-if v1.0.0 to dependencies
             Features:
             - compiler_builtins
             - core
             - rustc-dep-of-std
```

After building, run the command with execution files in the target dir.
As expected an error occurred.
```
% cargo build   
% ./target/xtask/debug/xtask dependencies unused
[2024-09-08T12:24:21Z INFO  tracel_xtask] Execution environment: std
[2024-09-08T12:24:21Z INFO  tracel_xtask::commands::dependencies] Cargo: run unused dependencies checks
[2024-09-08T12:24:21Z INFO  tracel_xtask::utils::process] Command line: cargo machete
Analyzing dependencies of crates in this directory...
cargo-machete found the following unused dependencies in .:
tracel-xtask -- ./crates/tracel-xtask/Cargo.toml:
        cfg-if

If you believe cargo-machete has detected an unused dependency incorrectly,
you can add the dependency to the list of dependencies to ignore in the
`[package.metadata.cargo-machete]` section of the appropriate Cargo.toml.
For example:

[package.metadata.cargo-machete]
ignored = ["prost"]

You can also try running it with the `--with-metadata` flag for better accuracy,
though this may modify your Cargo.lock files.

Done!
Error: Unused dependencies found!
```
