### PR TITLE
chore: update env_logger since dep is unmaintained

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "1.1.8"
+version = "1.1.9"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
@@ -20,7 +20,7 @@ anyhow = "1.0.86"
 clap = { version = "4.5.9", features = ["derive"] }
 derive_more = { version = "0.99.18", features = ["display"], default-features = false }
 dotenv = "0.15.0"
-env_logger = "0.11.3"
+env_logger = "0.11.7"
 log = { version = "0.4.22" }
 proc-macro2 = "1.0.86"
 quote = "1.0.36"

--- a/crates/tracel-xtask/Cargo.toml
+++ b/crates/tracel-xtask/Cargo.toml
@@ -22,7 +22,7 @@ regex = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 tracing-subscriber = { workspace = true }
-tracel-xtask-macros = { path = "../tracel-xtask-macros", version = "=1.1.8" }
+tracel-xtask-macros = { path = "../tracel-xtask-macros", version = "=1.1.9" }
 
 [dev-dependencies]
 rstest = { workspace = true }


### PR DESCRIPTION
`humantime` is unmaintained, and it breaks `burn`'s workflow since it throws when running audit. This updates that env_logger dependency to get rid of that issue.