### PR TITLE
Make `run_unit_test` pub

### DIFF
--- a/crates/tracel-xtask/src/commands/test.rs
+++ b/crates/tracel-xtask/src/commands/test.rs
@@ -142,7 +142,7 @@ pub fn run_unit(target: &Target, args: &TestCmdArgs) -> Result<()> {
     anyhow::Ok(())
 }
 
-fn run_unit_test(member: &WorkspaceMember, args: &TestCmdArgs) -> Result<(), anyhow::Error> {
+pub fn run_unit_test(member: &WorkspaceMember, args: &TestCmdArgs) -> Result<(), anyhow::Error> {
     group!("Unit Tests: {}", member.name);
     let test = args.test.as_deref().unwrap_or("");
     let mut cmd_args = vec![


### PR DESCRIPTION
This way we can directly run unit tests for a specific member without having to go through a filters list (only or exclude).

```rust
base_commands::test::run_unit_test(&member, args)
```